### PR TITLE
nsc-events-android-2-12-change-sdk-from-33-to-34

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,12 +5,12 @@ plugins {
 
 android {
     namespace 'com.example.nsc_events'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         applicationId "com.example.nsc_events"
-        minSdk 33
-        targetSdk 33
+        minSdk 34
+        targetSdk 34
         versionCode 1
         versionName "1.0"
 


### PR DESCRIPTION
Updates sdk to 34 from 33 which was linked to some inconsistencies.
fixes: https://github.com/SeattleColleges/nsc-events-android/issues/12