### PR TITLE
ignored all .env Excluded .env.sample from ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,7 @@ google-services.json
 *.hprof
 
 
-*.iml
+
 .gradle
 /local.properties
 /.idea/caches
@@ -47,4 +47,7 @@ google-services.json
 /captures
 .externalNativeBuild
 .cxx
-local.properties
+
+# secrets
+.env*
+!.env.sample


### PR DESCRIPTION
Added .env* to ignore list - excluding all .env files
.env.local .env.dev .env.production etc.

Excluded.
.env.sample. This will be our placeholder for env variable properties