### PR TITLE
Updated Gradle plugin to 8.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '8.0.2' apply false
-    id 'com.android.library' version '8.0.2' apply false
+    id 'com.android.application' version '8.1.0' apply false
+    id 'com.android.library' version '8.1.0' apply false
     id 'org.jetbrains.kotlin.android' version '1.8.22' apply false
     id("org.jetbrains.kotlinx.kover") version "0.7.2"
 }


### PR DESCRIPTION
I ran the app after updating the Gradle plugin to 8.1.0 which when used to compile agains SDK 34 does not give any warnings.

Note: 

The squash and merge will need overridden because the update to the ci workflow is in the next pr. Once done it will work as expected.

closes #32 