### PR TITLE
Updated CI to use gradle version 8.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        gradle-version: [ 8.2.1 ]
+        gradle-version: [ 8.1.0 ]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Once the previous PR #32 gets merged, this will use the gradle version everyone will be using locally. It will prevent any unexpected errors that may arise from code implementations working in one version and not the other.

dependent on #32 being merged first
