### PR TITLE
Home Page Addition #29

### DIFF
--- a/app/src/main/java/com/example/nsc_events/Routes.kt
+++ b/app/src/main/java/com/example/nsc_events/Routes.kt
@@ -5,4 +5,5 @@ sealed class Routes(val route: String) {
     object SignUp : Routes("SignUp")
 
     object AddEvent: Routes("Add Event")
+    object HomePage: Routes("Home")
 }

--- a/app/src/main/java/com/example/nsc_events/screen/HomePage.kt
+++ b/app/src/main/java/com/example/nsc_events/screen/HomePage.kt
@@ -1,0 +1,68 @@
+package com.example.nsc_events.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavHostController
+import com.example.nsc_events.Routes
+
+@Composable
+fun HomePage(navController: NavHostController) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(color = MaterialTheme.colorScheme.background)
+            .padding(16.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "Welcome to NSC Events",
+            style = TextStyle(
+                fontSize = 24.sp,
+                fontFamily = FontFamily.Default,
+                fontWeight = FontWeight.Bold,
+                color = if (isSystemInDarkTheme()) {
+                    Color.White
+                } else {
+                    Color.Black
+                }
+            )
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Button(
+            onClick = {
+                navController.navigate(Routes.Login.route)
+            }
+        ) {
+            Text(text = "Sign-in / Sign-up")
+
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+        Button(
+            onClick = {
+                navController.navigate(Routes.AddEvent.route)
+            }
+        ) {
+            Text(text = "Add Event")
+        }
+
+    }
+}

--- a/app/src/main/java/com/example/nsc_events/screen/Login.kt
+++ b/app/src/main/java/com/example/nsc_events/screen/Login.kt
@@ -15,7 +15,11 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.text.ClickableText
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
@@ -56,6 +60,13 @@ fun LoginPage(navController: NavHostController) {
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
+        IconButton(
+            onClick = { navController.navigate(Routes.HomePage.route) },
+            modifier = Modifier.align(Alignment.Start)
+        ) {
+            Icon(imageVector = Icons.Default.ArrowBack, contentDescription = "Home")
+        }
+
         Image(
             painter = painterResource(id = R.drawable.packaging),
             contentDescription = stringResource(id = R.string.login_logo_description),
@@ -174,7 +185,10 @@ fun LoginPage(navController: NavHostController) {
                     onClick = {
                         navController.navigate(Routes.AddEvent.route)
                     },
-                    modifier = Modifier.padding(16.dp).width(200.dp).align(Alignment.CenterHorizontally)
+                    modifier = Modifier
+                        .padding(16.dp)
+                        .width(200.dp)
+                        .align(Alignment.CenterHorizontally)
                 ) {
                     Text(text = "Add Event")
                 }

--- a/app/src/main/java/com/example/nsc_events/screen/ScreenMain.kt
+++ b/app/src/main/java/com/example/nsc_events/screen/ScreenMain.kt
@@ -10,8 +10,11 @@ import com.example.nsc_events.Routes
 fun ScreenMain(){
     val navController = rememberNavController()
 
-    NavHost(navController = navController, startDestination = Routes.Login.route) {
+    NavHost(navController = navController, startDestination = Routes.HomePage.route) {
 
+        composable(Routes.HomePage.route) {
+            HomePage(navController  = navController)
+        }
         composable(Routes.Login.route) {
             LoginPage(navController = navController)
         }


### PR DESCRIPTION
resolve #29 

Added a skeletal home page that routes to the sign-in/add events page. Home page is bare bones so any feedback on layout would be greatly appreciated. From those pages, you can go back to home page. 

<img width="432" alt="Screenshot 2023-08-22 at 12 43 31 PM" src="https://github.com/SeattleColleges/nsc-events-android/assets/116779961/79b7cb53-e75b-4bc7-881d-3135ec92a9ec">
