### PR TITLE
Refactor gradle plugin update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        gradle-version: [ 8.1.0 ]
+        gradle-version: [ 8.1.1 ]
 
     steps:
       - uses: actions/checkout@v3

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '8.1.0' apply false
-    id 'com.android.library' version '8.1.0' apply false
+    id 'com.android.application' version '8.1.1' apply false
+    id 'com.android.library' version '8.1.1' apply false
     id 'org.jetbrains.kotlin.android' version '1.8.22' apply false
     id("org.jetbrains.kotlinx.kover") version "0.7.2"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Jun 28 05:42:46 PDT 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
As a lead developer I updated the gradle wrapper to 8.2.1. No more compileSdk 34 warnings, yay!

The gradle plugin has been updated to 8.1.1. I met with @bcko, and he said this is fine. We must wait for Android to update the plugin to match the wrapper. 

Also, I updated the ci.yml to reflect the changes. The gradle wrapper successfully uses version 8.2.1


resolves #37 