### PR TITLE
nsc_android_enhancement_143_forgot-password

### DIFF
--- a/app/src/main/java/com/example/nsc_events/data/network/auth/ForgotPasswordService.kt
+++ b/app/src/main/java/com/example/nsc_events/data/network/auth/ForgotPasswordService.kt
@@ -1,0 +1,37 @@
+package com.example.nsc_events.data.network.auth
+
+import com.example.nsc_events.data.network.dto.auth_dto.ForgotPasswordRequest
+import com.example.nsc_events.data.network.dto.auth_dto.ForgotPasswordResponse
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.android.Android
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.logging.DEFAULT
+import io.ktor.client.plugins.logging.LogLevel
+import io.ktor.client.plugins.logging.Logger
+import io.ktor.client.plugins.logging.Logging
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.json.Json
+
+interface ForgotPasswordService {
+    suspend fun forgotPassword(forgotPasswordService: ForgotPasswordRequest) : ForgotPasswordResponse?
+
+    companion object {
+        fun create() : ForgotPasswordService {
+            return ForgotPasswordServiceImpl(
+                client = HttpClient(Android) {
+                    install(ContentNegotiation) {
+                        json(Json {
+                            prettyPrint = true
+                            isLenient = true
+                            ignoreUnknownKeys = true
+                        })
+                    }
+                    install (Logging) {
+                        level = LogLevel.ALL
+                        logger = Logger.DEFAULT
+                    }
+                }
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/nsc_events/data/network/auth/ForgotPasswordServiceImpl.kt
+++ b/app/src/main/java/com/example/nsc_events/data/network/auth/ForgotPasswordServiceImpl.kt
@@ -1,0 +1,35 @@
+package com.example.nsc_events.data.network.auth
+
+import com.example.nsc_events.data.network.HttpRoutes
+import com.example.nsc_events.data.network.dto.auth_dto.ForgotPasswordRequest
+import com.example.nsc_events.data.network.dto.auth_dto.ForgotPasswordResponse
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.url
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.util.InternalAPI
+import kotlinx.serialization.json.Json
+
+class ForgotPasswordServiceImpl(
+    private val client: HttpClient
+) :
+    ForgotPasswordService {
+    @OptIn(InternalAPI::class)
+    override suspend fun forgotPassword(forgotPasswordRequest: ForgotPasswordRequest): ForgotPasswordResponse? {
+        return try {
+            val response = client.post {
+                url(HttpRoutes.FORGOT_PASSWORD)
+                header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                body = Json.encodeToString(ForgotPasswordRequest.serializer(), forgotPasswordRequest)
+            }
+            response.body()
+        } catch (e: Exception) {
+            println("Error: ${e.message}")
+            null
+        }
+    }
+
+}

--- a/app/src/main/java/com/example/nsc_events/data/network/dto/auth_dto/ForgotPasswordRequest.kt
+++ b/app/src/main/java/com/example/nsc_events/data/network/dto/auth_dto/ForgotPasswordRequest.kt
@@ -1,0 +1,10 @@
+package com.example.nsc_events.data.network.dto.auth_dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ForgotPasswordRequest(
+    @SerialName("email")
+    val email: String
+)

--- a/app/src/main/java/com/example/nsc_events/data/network/dto/auth_dto/ForgotPasswordResponse.kt
+++ b/app/src/main/java/com/example/nsc_events/data/network/dto/auth_dto/ForgotPasswordResponse.kt
@@ -1,0 +1,10 @@
+package com.example.nsc_events.data.network.dto.auth_dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ForgotPasswordResponse(
+    @SerialName("newToken")
+    val newToken: String
+)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,4 +21,8 @@
     <!--    Sign Up Screen Strings    -->
     <string name="signup_successful_toast">Sign up successful!</string>
     <string name="signup_failed_toast">Sign up failed, please try again!</string>
+
+    <!--    Reset Password Screen Strings    -->
+    <string name="forgot_password_success_reset_token">Success reset token! Please check Logcat!</string>
+    <string name="forgot_password_invalid_email">Invalid email, please try again!</string>
 </resources>


### PR DESCRIPTION
Resolves #143 
This PR will allow users to get the new token to reset their password.

- [x] 1. Create forgot password dtos (request + response)
- [x] 2. Create a service that will call the forgot password API from the backend.
- [x] 3. Add the resetToken function to the button.

_Note:_ Currently, we are using the log to print the new token. We will decide on other solutions such as sending a new token (password) via email or phone number:
- Email with Nodemailer

DEMO:

https://github.com/SeattleColleges/nsc-events-android/assets/72054441/00076ffc-c1df-4d5b-92da-0dac777ed380

