### PR TITLE
nsc-events-android_184_admin-creator-view-routing

### DIFF
--- a/app/src/main/java/com/example/nsc_events/screen/Login.kt
+++ b/app/src/main/java/com/example/nsc_events/screen/Login.kt
@@ -292,7 +292,14 @@ suspend fun loginWithValidCredentials(email: String, password: String, navContro
             MainActivity.getPref().edit().putString("userRole", userRole.name).apply()
 
             MainActivity.getPref().edit().putString("token", loginResponse.token).apply()
-            navController.navigate(Routes.AddEvent.route)
+
+            // navigating to proper page based on user's role
+            when (userRole) {
+                Role.ADMIN -> navController.navigate(Routes.AdminView.route)
+                Role.CREATOR -> navController.navigate(Routes.CreatorView.route)
+                else -> navController.navigate(Routes.HomePage.route)
+            }
+
             Toast.makeText(
                 current,
                 "Welcome ${getName(loginResponse.token)} to NSC Events!",


### PR DESCRIPTION
Resolves #184 

This pr routes a user with admin or creator roles to the proper pages giving those users more permissions and access to create events and edit user roles

To test:
- Create two separate accounts on the backend giving them specific roles (one for admin and creator), or just add them into mongo db inserting two separate accounts one for admin and creator. 
- Need to have the backend running and start up the android application. Then go login page and log in with the two different accounts 

<img width="1728" alt="Screenshot 2023-12-08 at 1 39 30 PM" src="https://github.com/SeattleColleges/nsc-events-android/assets/116779961/ce3349b4-73a0-426a-8dbb-54fd0e9657c2">
<img width="1728" alt="Screenshot 2023-12-08 at 1 39 49 PM" src="https://github.com/SeattleColleges/nsc-events-android/assets/116779961/036f2631-85dd-43e2-bf0a-d8ef6a4c4cdf">
