### PR TITLE
nsc-events-android_2_190_update-toast-message

### DIFF
--- a/app/src/main/java/com/example/nsc_events/data/network/dto/auth_dto/SignUpRequest.kt
+++ b/app/src/main/java/com/example/nsc_events/data/network/dto/auth_dto/SignUpRequest.kt
@@ -17,8 +17,11 @@ enum class Role(val role: String) {
 
 @Serializable
 data class SignUpRequest(
-    @SerialName("name")
-    val name: String,
+    @SerialName("firstName")
+    val firstName: String,
+
+    @SerialName("lastName")
+    val lastName: String,
 
     @SerialName("email")
     val email: String,

--- a/app/src/main/java/com/example/nsc_events/screen/Login.kt
+++ b/app/src/main/java/com/example/nsc_events/screen/Login.kt
@@ -341,7 +341,7 @@ fun getName(token: String): String? {
         val payload = token.split(".")[1]
         val decodedPayload = String(Base64.decode(payload, Base64.DEFAULT))
         val jsonObject = JSONObject(decodedPayload)
-        jsonObject.getString("name")
+        jsonObject.getString("firstName")
     } catch (e: Exception) {
         e.printStackTrace()
         null

--- a/app/src/main/java/com/example/nsc_events/screen/SignUp.kt
+++ b/app/src/main/java/com/example/nsc_events/screen/SignUp.kt
@@ -287,9 +287,9 @@ fun SignUpPage(navController: NavHostController) {
                             onClick =
                             {
                               keyboardController?.hide()
-                              if (firstName.isNotBlank() && validateEmail(email) && validatePassword(password) && validateConfirmPassword(password, confirmPassword)) {
+                              if (firstName.isNotBlank() && lastName.isNotBlank() && validateEmail(email) && validatePassword(password) && validateConfirmPassword(password, confirmPassword)) {
                                 coroutineScope.launch {
-                                  signUp(firstName, email, password, navController, current)
+                                  signUp(firstName, lastName, email, password, navController, current)
                                 }
                               } else {
                                 // Update error flags to show error messages
@@ -327,19 +327,20 @@ fun validateConfirmPassword(password: String, confirmPassword: String): Boolean 
     return password.isNotEmpty() && password.isNotBlank() && password == confirmPassword
 }
 
-fun validateFirstName(name: String): Boolean {
+fun validateFirstName(firstName: String): Boolean {
     // Add your validation logic here
-    return name.isNotBlank()
+    return firstName.isNotBlank()
 }
 
-fun validateLastName(name: String): Boolean {
+fun validateLastName(lastName: String): Boolean {
     // Add your validation logic here
-    return name.isNotBlank()
+    return lastName.isNotBlank()
 }
 
 
 suspend fun signUp(
-    name: String,
+    firstName: String,
+    lastName: String,
     email: String,
     password: String,
     navController: NavHostController,
@@ -347,7 +348,8 @@ suspend fun signUp(
 ) {
     return try {
         val signUpRequest = SignUpRequest(
-            name = name,
+            firstName = firstName,
+            lastName = lastName,
             email = email,
             password = password,
             role = Role.ADMIN


### PR DESCRIPTION
Resolves #190 

I updated the Toast message "Welcome null to NSC Events!" to display the user's name instead of null on the Login page.

Note: null will appear if you use your old login without the updated schema; you should be using an account with the updated schema.

<img width="116" alt="Screenshot 2024-01-27 235142" src="https://github.com/SeattleColleges/nsc-events-android/assets/77607212/20eec474-f954-4d99-b835-c82cd51cd5ac">

Related to User Story #188 and this [PR](https://github.com/SeattleColleges/nsc-events-nestjs/pull/73)