### PR TITLE
nsceventsandroid_sprint5_226_removesignup

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A student-developed application for advertising and viewing events hosted by the
 
 📈 **Outcome**: By participating in this project, students gain hands-on experience, learning best practices and methodologies that are crucial in today's fast-paced software development landscape.
 
----
+--- 
 
 ## Table of Contents
 

--- a/app/src/main/java/com/example/nsc_events/screen/HomePage.kt
+++ b/app/src/main/java/com/example/nsc_events/screen/HomePage.kt
@@ -105,9 +105,6 @@ fun HomePage(navController: NavHostController) { // Create Navbar
                             modifier = Modifier.padding(8.dp)
                         ) {
                             // Dropdown menu items
-                            TextButton(onClick = { navController.navigate(Routes.SignUp.route) }) {
-                                Text("Sign Up", color = Color.Black)
-                            }
                             TextButton(onClick = { navController.navigate(Routes.Login.route) }) {
                                 Text("Login", color = Color.Black)
                             }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '8.1.1' apply false
-    id 'com.android.library' version '8.1.1' apply false
+    id 'com.android.application' version '8.3.2' apply false
+    id 'com.android.library' version '8.3.2' apply false
     id 'org.jetbrains.kotlin.android' version '1.8.22' apply false
     id("org.jetbrains.kotlinx.kover") version "0.7.2"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Jun 28 05:42:46 PDT 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Resolves #226 
This PR removes the signup link from the navigation menu.

![Screenshot 2024-04-16 201042](https://github.com/SeattleColleges/nsc-events-android/assets/52189566/f3886ea2-5c8e-416c-9fe8-bb9869144764)
